### PR TITLE
Fixed flaky test for testHandleNotificationWithOversizedPayload test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ _site
 *.ipr
 *.iws
 .idea/
+.nondex/

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/auth/AuthenticationToken.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/auth/AuthenticationToken.java
@@ -38,6 +38,7 @@ import java.security.SignatureException;
 import java.text.ParseException;
 import java.time.Instant;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -86,7 +87,7 @@ public class AuthenticationToken {
         }
 
         Map<String, Object> toMap() {
-            final Map<String, Object> headerMap = new HashMap<>(3, 1);
+            final Map<String, Object> headerMap = new LinkedHashMap<>(3, 1);
             headerMap.put("alg", "ES256");
             headerMap.put("typ", "JWT");
             headerMap.put("kid", this.keyId);
@@ -129,7 +130,7 @@ public class AuthenticationToken {
         }
 
         Map<String, Object> toMap() {
-            final Map<String, Object> headerMap = new HashMap<>(2, 1);
+            final Map<String, Object> headerMap = new LinkedHashMap<>(2, 1);
             headerMap.put("iss", this.issuer);
             headerMap.put("iat", this.issuedAt.getEpochSecond());
 

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/server/ValidatingPushNotificationHandler.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/server/ValidatingPushNotificationHandler.java
@@ -155,7 +155,6 @@ abstract class ValidatingPushNotificationHandler implements PushNotificationHand
             }
         }
 
-
         if (payload == null || payload.readableBytes() == 0) {
             throw new RejectedNotificationException(RejectionReason.PAYLOAD_EMPTY);
         }

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/server/ValidatingPushNotificationHandler.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/server/ValidatingPushNotificationHandler.java
@@ -61,7 +61,7 @@ abstract class ValidatingPushNotificationHandler implements PushNotificationHand
 
     @Override
     public void handlePushNotification(final Http2Headers headers, final ByteBuf payload) throws RejectedNotificationException {
-
+	
         try {
             final CharSequence apnsIdSequence = headers.get(APNS_ID_HEADER);
 
@@ -155,7 +155,6 @@ abstract class ValidatingPushNotificationHandler implements PushNotificationHand
             }
         }
 
-        this.verifyAuthentication(headers);
 
         if (payload == null || payload.readableBytes() == 0) {
             throw new RejectedNotificationException(RejectionReason.PAYLOAD_EMPTY);
@@ -164,6 +163,8 @@ abstract class ValidatingPushNotificationHandler implements PushNotificationHand
         if (payload.readableBytes() > MAX_PAYLOAD_SIZE) {
             throw new RejectedNotificationException(RejectionReason.PAYLOAD_TOO_LARGE);
         }
+
+	this.verifyAuthentication(headers);
     }
 
     protected abstract void verifyAuthentication(final Http2Headers headers) throws RejectedNotificationException;

--- a/pushy/src/test/java/com/eatthepath/pushy/apns/server/ValidatingPushNotificationHandlerTest.java
+++ b/pushy/src/test/java/com/eatthepath/pushy/apns/server/ValidatingPushNotificationHandlerTest.java
@@ -213,9 +213,6 @@ public abstract class ValidatingPushNotificationHandlerTest {
     @Test
     void testHandleNotificationWithDeviceTokenForWrongTopic() {
         this.headers.set(APNS_TOPIC_HEADER, TOPIC + ".definitely.wrong");
-	System.out.println("##############################");
-        System.out.println(this.headers);
-	System.out.println(this.payload);
         this.assertNotificationRejected("Push notifications with a device token for the wrong topic should be rejected.",
                 this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.emptyMap()),
                 this.headers,

--- a/pushy/src/test/java/com/eatthepath/pushy/apns/server/ValidatingPushNotificationHandlerTest.java
+++ b/pushy/src/test/java/com/eatthepath/pushy/apns/server/ValidatingPushNotificationHandlerTest.java
@@ -213,7 +213,9 @@ public abstract class ValidatingPushNotificationHandlerTest {
     @Test
     void testHandleNotificationWithDeviceTokenForWrongTopic() {
         this.headers.set(APNS_TOPIC_HEADER, TOPIC + ".definitely.wrong");
-
+	System.out.println("##############################");
+        System.out.println(this.headers);
+	System.out.println(this.payload);
         this.assertNotificationRejected("Push notifications with a device token for the wrong topic should be rejected.",
                 this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.emptyMap()),
                 this.headers,
@@ -255,7 +257,6 @@ public abstract class ValidatingPushNotificationHandlerTest {
             new Random().nextBytes(payloadBytes);
 
             largePayload.writeBytes(payloadBytes);
-
             this.assertNotificationRejected("Push notifications with a device token for the wrong topic should be rejected.",
                     this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.emptyMap()),
                     this.headers,


### PR DESCRIPTION
Detected and fixed flaky test for testHandleNotificationWithOversizedPayload using the NonDex Tool.

### Issue:
The issue was that the token signature was being verified by comparing HashMap of headers and claims by converting them to strings and comparing the strings. Since, HashMap ordering is not gauranteed, the test became flaky.  This caused the <INVALID_TOKEN> error being thrown first instead of the <PAYLOAD_TOO_LARGE> error. 

### Fix:
Converted the headers and claims HashMap to LinkedHashMap. I also moved the verifyAuthentication() call after the payload size checks. In all other test cases, the checks in the handlePushNotification() function were being done before calling verifyAuthentication(). However, the payload size checks were being performed after the verifyAuthentication(). This second enhancement leads to better fault isolation as Payload size checks are done earlier. 

These fixes fixed the issue with the incorrect error being thrown and now all the NonDex tool tests pass. 